### PR TITLE
Remove "set-output" usage from GitHub Action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven


### PR DESCRIPTION
On our current GitHub Action run there is this warning:

> *Build JDK 8*
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="1088" alt="GitHub Action Warning" src="https://github.com/jmini/gitlab4j-api/assets/1222165/6cd6dd63-4826-4ccf-b117-58af3f19d9ee">

This PR is setting the output parameter according to the documentation:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
